### PR TITLE
initial commit of ECR and ECS modules

### DIFF
--- a/ecr/create-resource/main.tf
+++ b/ecr/create-resource/main.tf
@@ -1,0 +1,4 @@
+resource "aws_ecr_repository" "service" {
+  name                 = "${var.repository_name}"
+  image_tag_mutability = "MUTABLE"
+}

--- a/ecr/create-resource/main.tf
+++ b/ecr/create-resource/main.tf
@@ -1,4 +1,4 @@
 resource "aws_ecr_repository" "service" {
   name                 = "${var.repository_name}"
-  image_tag_mutability = "MUTABLE"
+  image_tag_mutability = "IMMUTABLE"
 }

--- a/ecr/create-resource/output.tf
+++ b/ecr/create-resource/output.tf
@@ -1,0 +1,11 @@
+output "repository_arn" {
+  value = "${aws_ecr_repository.service.arn}"
+}
+
+output "repository_name" {
+  value = "${aws_ecr_repository.service.name}"
+}
+
+output "repository_url" {
+  value = "${aws_ecr_repository.service.repository_url}"
+}

--- a/ecr/create-resource/variables.tf
+++ b/ecr/create-resource/variables.tf
@@ -1,0 +1,1 @@
+variable "repository_name" {}

--- a/ecs/create-resource/data.tf
+++ b/ecs/create-resource/data.tf
@@ -1,0 +1,8 @@
+data "aws_lb" "command_query_alb" {
+  name = "command-query-alb-${var.environment}"
+}
+
+data "aws_lb_listener" "alb_https_listener" {
+  load_balancer_arn = "${data.aws_lb.command_query_alb.arn}"
+  port              = 443
+}

--- a/ecs/create-resource/main.tf
+++ b/ecs/create-resource/main.tf
@@ -1,0 +1,46 @@
+resource "aws_ecs_task_definition" "service" {
+  family                = "${var.family}"
+  container_definitions = "${var.container_definitions}"
+  task_role_arn = "${var.task_role_arn}"
+}
+
+resource "aws_lb_target_group" "target_group" {
+  name     = "${var.service_name}"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "${var.vpc_id}"
+  health_check {    
+    healthy_threshold   = 5    
+    unhealthy_threshold = 2    
+    timeout             = 5    
+    interval            = 30    
+    path                = "${var.health_check_path}"    
+    port                = "traffic-port"
+    matcher             = "200-299"
+  }
+}
+
+resource "aws_lb_listener_rule" "target_group_listener_rule" {
+  listener_arn = "${data.aws_lb_listener.alb_https_listener.arn}"
+  priority     = var.alb_rule_priority
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.target_group.arn}"
+  }
+  condition {
+    field  = "path-pattern"
+    values = ["${var.alb_rule_path}"]
+  }
+}
+
+resource "aws_ecs_service" "service" {
+  name            = "${var.service_name}"
+  cluster         = "${var.cluster_id}"
+  task_definition = "${aws_ecs_task_definition.service.arn}"
+  desired_count   = var.desired_count
+  load_balancer {
+    target_group_arn = "${aws_lb_target_group.target_group.arn}"
+    container_name   = "${var.container_name}"
+    container_port   = "${var.container_port}"
+  }
+}

--- a/ecs/create-resource/variables.tf
+++ b/ecs/create-resource/variables.tf
@@ -1,0 +1,22 @@
+variable "alb_rule_path" {}
+variable "alb_rule_priority" {
+  type = number
+}
+variable "cluster_id" {}
+variable "container_definitions" {}
+variable "container_name" {}
+variable "container_port" {}
+variable "desired_count" {
+  type = number
+}
+variable "environment" {
+  description = ""
+}
+variable "family" {}
+variable "health_check_path" {}
+variable "service_name" {}
+variable "task_role_arn" {}
+variable "vpc_id" {}
+
+
+


### PR DESCRIPTION
I have a feeling we may want to pull apart some of the load balancer stuff from the ECS module. We (HAAS) currently deploy "command" and "query" containers for each API aggregate behind that load balancer, but it might make sense to allow for deploying containers independently.